### PR TITLE
Removing the `-warnings-as-errors` Swift setting.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,6 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] {
     [
-        .swiftLanguageMode(.v6),
-        .unsafeFlags(["-warnings-as-errors"])
+        .swiftLanguageMode(.v6)
     ]
 }


### PR DESCRIPTION
It was causing the following error in projects that attempted to depend on `DecimalMacro`:

```
The package product 'DecimalMacro' cannot be used as a dependency of this target because it uses unsafe build flags.
```