### PR TITLE
Updating the expanded macro to call `Decimal.init(sign:exponent:significand:)`.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "DecimalMacro",
-    platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
+    platforms: [.macOS(.v13), .iOS(.v13), .tvOS(.v13), .watchOS(.v6), .macCatalyst(.v13)],
     products: [
         .library(
             name: "DecimalMacro",

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ Initialising with `Decimal(3.24)` invokes `init(_ value: Double)`.
 See the problem? The literal you supply is converted to a `Double` and then to `Decimal`. This introduces floating point 
 precision problems. Avoiding these problems is probably why you wanted to use `Decimal` in the first place. 
 
-You can initialise a precise `Decimal` value in Swift:
+Without the macro you can initialise a precise `Decimal` value in Swift:
 
 1. From a string literal - e.g. `Decimal(string: "3.24")!`
 2. From an exponent and significand - e.g. `Decimal(sign: .plus, exponent: -2, significand: 324)`
 
-If you use option 1 you lose compile time type checking.
+If you use option 1 you lose compile time type checking, and incur the cost of parsing a string at runtime.
 
 If you use option 2 your code becomes hard to read and write.
 
@@ -87,14 +87,20 @@ This code:
 Takes the floating point literal you supply and expands to:
 
 ```swift
-Decimal(string: "3.24")!
+Decimal(sign: .plus, exponent: -2, significand: 324)
 ```
 
 This way:
  
 1. You retain compile time type checking.
 2. Your code is easy to read and write.
-3. The expanded code is easy to compare to the code you wrote. 
+3. The expanded code doesn't incur the cost of parsing a string at runtime. 
+
+## Limitations
+
+The `#decimal` macro accepts decimal floating point literal arguments. 
+
+A compilation error will occur if `#decimal` is passed binary, octal, or hexidecimal literals.  
 
 ## License
 

--- a/Sources/DecimalMacroImpl/DecimalMacroError.swift
+++ b/Sources/DecimalMacroImpl/DecimalMacroError.swift
@@ -8,13 +8,13 @@ public enum DecimalMacroError: Error, CustomStringConvertible {
     case noArguments
 
     /// The macro received an unsupported argument.
-    case unsupportedArgumentType(SyntaxProtocol.Type)
+    case unsupportedArgument(String)
 
     /// A textual representation of this error.
     public var description: String {
         switch self {
             case .noArguments: "No arguments received"
-            case .unsupportedArgumentType(let syntaxNodeType): "Unsupported argument type: \(syntaxNodeType)"
+            case .unsupportedArgument(let value): "Cannot parse '\(value)' as a 'Decimal'"
         }
     }
 

--- a/Tests/DecimalMacroTests/DecimalMacroErrorTests.swift
+++ b/Tests/DecimalMacroTests/DecimalMacroErrorTests.swift
@@ -5,15 +5,9 @@ import XCTest
 final class DecimalMacroErrorTests: XCTestCase {
 
     func testDescription() {
-        XCTAssertEqual(
-            DecimalMacroError.noArguments.description,
-            "No arguments received"
-        )
+        XCTAssertEqual(DecimalMacroError.noArguments.description, "No arguments received")
 
-        XCTAssertEqual(
-            DecimalMacroError.unsupportedArgumentType(StringLiteralExprSyntax.self).description,
-            "Unsupported argument type: StringLiteralExprSyntax"
-        )
+        XCTAssertEqual(DecimalMacroError.unsupportedArgument("foo").description, "Cannot parse 'foo' as a 'Decimal'")
     }
 
 }

--- a/Tests/DecimalMacroTests/DecimalMacroTests.swift
+++ b/Tests/DecimalMacroTests/DecimalMacroTests.swift
@@ -6,21 +6,101 @@ final class DecimalMacroTests: XCTestCase {
 
     private let testMacros = ["decimal": DecimalMacro.self]
 
-    func testMacroExpansion() {
-        assertMacroExpansion("#decimal(3.24)", expandedSource: "Decimal(string: \"3.24\")!", macros: testMacros)
-        assertMacroExpansion("#decimal(-7.14)", expandedSource: "Decimal(string: \"-7.14\")!", macros: testMacros)
+    func testMacroExpandsGivenDecimalFloatingPointLiteral() {
+        assertMacroExpansion(
+            "#decimal(3.24)",
+            expandedSource: "Decimal(sign: .plus, exponent: -2, significand: 324)",
+            macros: testMacros
+        )
 
-        assertMacroExpansion("#decimal(0.0)", expandedSource: "Decimal(string: \"0.0\")!", macros: testMacros)
-        assertMacroExpansion("#decimal(-0.0)", expandedSource: "Decimal(string: \"-0.0\")!", macros: testMacros)
+        assertMacroExpansion(
+            "#decimal(+1.001)",
+            expandedSource: "Decimal(sign: .plus, exponent: -3, significand: 1001)",
+            macros: testMacros
+        )
 
-        assertMacroExpansion("#decimal(3)", expandedSource: "Decimal(string: \"3\")!", macros: testMacros)
-        assertMacroExpansion("#decimal(-7)", expandedSource: "Decimal(string: \"-7\")!", macros: testMacros)
+        assertMacroExpansion(
+            "#decimal(-7.141)",
+            expandedSource: "Decimal(sign: .minus, exponent: -3, significand: 7141)",
+            macros: testMacros
+        )
 
-        assertMacroExpansion("#decimal(0)", expandedSource: "Decimal(string: \"0\")!", macros: testMacros)
-        assertMacroExpansion("#decimal(-0)", expandedSource: "Decimal(string: \"-0\")!", macros: testMacros)
+        assertMacroExpansion(
+            "#decimal(0.0)",
+            expandedSource: "Decimal(sign: .plus, exponent: -1, significand: 0)",
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(-0.0)",
+            expandedSource: "Decimal(sign: .plus, exponent: 0, significand: 0)",  // `Decimal` can't represent -0
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(1_234.5)",
+            expandedSource: "Decimal(sign: .plus, exponent: -1, significand: 12345)",
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(1.23e4)",
+            expandedSource: "Decimal(sign: .plus, exponent: 2, significand: 123)",
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(1.23e+4)",
+            expandedSource: "Decimal(sign: .plus, exponent: 2, significand: 123)",
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(1.23E-2)",
+            expandedSource: "Decimal(sign: .plus, exponent: -4, significand: 123)",
+            macros: testMacros
+        )
     }
 
-    func testMacroFailure() {
+    func testMacroExpandsGivenDecimalIntegerLiteral() {
+        assertMacroExpansion(
+            "#decimal(3)",
+            expandedSource: "Decimal(sign: .plus, exponent: 0, significand: 3)",
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(+5)",
+            expandedSource: "Decimal(sign: .plus, exponent: 0, significand: 5)",
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(-7)",
+            expandedSource: "Decimal(sign: .minus, exponent: 0, significand: 7)",
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(0)",
+            expandedSource: "Decimal(sign: .plus, exponent: 0, significand: 0)",
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(-0)",
+            expandedSource: "Decimal(sign: .plus, exponent: 0, significand: 0)",  // `Decimal` can't represent -0
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(1_234)",
+            expandedSource: "Decimal(sign: .plus, exponent: 0, significand: 1234)",
+            macros: testMacros
+        )
+    }
+
+    func testMacroFailsGivenNoArguments() {
         assertMacroExpansion(
             "#decimal()",
             expandedSource: "#decimal()",
@@ -29,12 +109,62 @@ final class DecimalMacroTests: XCTestCase {
             ],
             macros: testMacros
         )
+    }
 
+    func testMacroFailsGivenNonDecimalFloatingPointLiteral() {
+        // `DecimalMacro` only supports decimal floating point literals. The following will fail:
+        // - Hexadecimal literals such as `0xA.Bp2` (decimal `42.75`).
+
+        assertMacroExpansion(
+            "#decimal(0xA.Bp2)",
+            expandedSource: "#decimal(0xA.Bp2)",
+            diagnostics: [
+                DiagnosticSpec(message: "Cannot parse '0xA.Bp2' as a 'Decimal'", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    }
+
+    func testMacroFailsGivenNonDecimalIntegerLiteral() {
+        // `DecimalMacro` only supports decimal integer literals. The following will fail:
+        // - Binary literals such as `0b101` (decimal `5`).
+        // - Octal Literals such as `0o123` (decimal `83`).
+        // - Hexadecimal literals such as `0xABC` (decimal `2748`).
+
+        assertMacroExpansion(
+            "#decimal(0b101)",
+            expandedSource: "#decimal(0b101)",
+            diagnostics: [
+                DiagnosticSpec(message: "Cannot parse '0b101' as a 'Decimal'", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(0o123)",
+            expandedSource: "#decimal(0o123)",
+            diagnostics: [
+                DiagnosticSpec(message: "Cannot parse '0o123' as a 'Decimal'", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+
+        assertMacroExpansion(
+            "#decimal(0xABC)",
+            expandedSource: "#decimal(0xABC)",
+            diagnostics: [
+                DiagnosticSpec(message: "Cannot parse '0xABC' as a 'Decimal'", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    }
+
+    func testMacroFailsGivenDoubleConstant() {
         assertMacroExpansion(
             "#decimal(Double.nan)",
             expandedSource: "#decimal(Double.nan)",
             diagnostics: [
-                DiagnosticSpec(message: "Unsupported argument type: MemberAccessExprSyntax", line: 1, column: 1)
+                DiagnosticSpec(message: "Cannot parse 'Double.nan' as a 'Decimal'", line: 1, column: 1)
             ],
             macros: testMacros
         )


### PR DESCRIPTION
Also improving literal support to:
- Handle grouping characters. E.g. `1_234.5`.
- Reject unsupported binary, octal, or hexadecimal literals.